### PR TITLE
Update installation command for dockerhound

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Press CTRL-C when you're done.
 
 ``` bash
 # Using uv (recommended):
-uv tool install dockerhound
+uv tool install git+https://github.com/SySS-Research/Single-User-BloodHound
 
 # Using pipx:
 pipx install dockerhound


### PR DESCRIPTION
Install dockerhound directly from GitHub with uv.

The installation from pypi could be behind the state of the GitHub repository. 

When installing the latest version from pypi (`uv tool install dockerhound`)  the `-h` flag was not yet available. However, when installing it directly from the GitHub repository, the flag is available. 